### PR TITLE
Bug 1780302: metrics/storage/podmetrics: ignore evicted pods

### DIFF
--- a/metrics/storage/podmetrics/reststorage.go
+++ b/metrics/storage/podmetrics/reststorage.go
@@ -87,6 +87,11 @@ func (m *MetricStorage) List(ctx genericapirequest.Context, options *metainterna
 
 	res := metrics.PodMetricsList{}
 	for _, pod := range pods {
+		if pod.Status.Phase != v1.PodRunning {
+			// ignore pod not in Running phase
+			continue
+		}
+
 		if podMetrics := m.getPodMetrics(pod); podMetrics != nil {
 			res.Items = append(res.Items, *podMetrics)
 		} else {


### PR DESCRIPTION
This is a backport of https://github.com/kubernetes-sigs/metrics-server/commit/0bf0c02b82bb236e8d6f145923a013f641f58b3e

/cc @openshift/openshift-team-monitoring 