### PR TITLE
MON-3257: Add OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,20 @@
+component: "Monitoring"
+
+reviewers:
+- simonpasquier
+- jan--f
+- raptorsun
+- slashpai
+- sthaha
+- danielmellado
+- marioferh
+
+approvers:
+- bparees
+- simonpasquier
+- jan--f
+- raptorsun
+- slashpai
+- sthaha
+- danielmellado
+- marioferh


### PR DESCRIPTION
As part of https://issues.redhat.com//browse/MON-3257 we will be deploying metrics-server which needs this repo to be updated. Currently monitoring team is not owners of this repo this PR is to add OWNERS file