### PR TITLE
WIP: pkg/api: fix singular name

### DIFF
--- a/pkg/api/node.go
+++ b/pkg/api/node.go
@@ -178,5 +178,5 @@ func (m *nodeMetrics) NamespaceScoped() bool {
 
 // GetSingularName implements rest.SingularNameProvider interface
 func (m *nodeMetrics) GetSingularName() string {
-	return "node"
+	return ""
 }

--- a/pkg/api/pod.go
+++ b/pkg/api/pod.go
@@ -185,5 +185,5 @@ func (m *podMetrics) NamespaceScoped() bool {
 
 // GetSingularName implements rest.SingularNameProvider interface
 func (m *podMetrics) GetSingularName() string {
-	return "pod"
+	return ""
 }


### PR DESCRIPTION
With the 1.27 Kubernetes upgrade, a new GetSingularName method needed to be implemented by the metrics rest.Storage. While doing it, we set a value for the singular name of the resources when it used to be empty. Due to that, the kube-apiserver stop guessing the resource name based on its Kind, which broken kubectl get PodMetrics/NodeMetrics.

To fix that, we need to blank out the singular name of the resources, otherwise we will be stuck with the following commands:
- kubectl get pod.metric
- kubectl get node.metric Instead of the more commonly used:
- kubectl get PodMetrics
- kubectl get NodeMetrics

Signed-off-by: Damien Grisonnet <dgrisonn@redhat.com>
(cherry picked from commit a9fdc887cfd06d2991940ca15e454f77261e678f)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

